### PR TITLE
main: recipes-core: Bump openjdk-8-jre from 8u382-b05 to 8u392-b08

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-openjdk-temurin = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-openjdk-temurin = "6"
 
 LAYERDEPENDS_meta-openjdk-temurin = "core"
-LAYERSERIES_COMPAT_meta-openjdk-temurin = "mickledore"
+LAYERSERIES_COMPAT_meta-openjdk-temurin = "langdale mickledore nanbield"

--- a/recipes-core/openjdk-8-jre/openjdk-8-jre_8u392-b08.bb
+++ b/recipes-core/openjdk-8-jre/openjdk-8-jre_8u392-b08.bb
@@ -18,7 +18,7 @@ JVM_RDEPENDS:aarch64 = " \
   libxrender (>= 0.9) \
   libxtst (>= 1.2) \
 "
-JVM_CHECKSUM:arm = "b92fb3972372b5d1f9fb51815def903105722b747f680b7ecf2ba2ba863ab156"
+JVM_CHECKSUM:arm = "877953bfabcdbcd000c11364d806456ca579a921085de2ca942280ebe168cac2"
 JVM_RDEPENDS:arm = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.11) \
@@ -31,7 +31,7 @@ JVM_RDEPENDS:arm = " \
   libxrender (>= 0.9) \
   libxtst (>= 1.2) \
 "
-JVM_CHECKSUM:x86_64 = "1fad165cc243e8db1b9cf226134acdfe3dc5919cd98c5fd9210de3cf9edeabd7"
+JVM_CHECKSUM:x86_64 = "91d31027da0d985be3549714389593d9e0da3da5057d87e3831c7c538b9a2a0f"
 JVM_RDEPENDS:x86_64 = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.11) \

--- a/recipes-core/openjdk-8-jre/openjdk-8-jre_8u392-b08.bb
+++ b/recipes-core/openjdk-8-jre/openjdk-8-jre_8u392-b08.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-with-classpath-exceptio
 COMPATIBLE_HOST = "(x86_64|arm|aarch64).*-linux"
 OVERRIDES = "${TARGET_ARCH}"
 
-JVM_CHECKSUM:aarch64 = "8cf329aa76d5b6abe35dd94e5087d9d14993fa13b43bbaed3b26bda4c57162c4"
+JVM_CHECKSUM:aarch64 = "37b997f12cd572da979283fccafec9ba903041a209605b50fcb46cc34f1a9917"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.11) \

--- a/recipes-support/libatomic/libatomic_1.0.bb
+++ b/recipes-support/libatomic/libatomic_1.0.bb
@@ -3,6 +3,8 @@ HOMEPAGE = "https://gcc.gnu.org/"
 LICENSE = "GPL-3.0-with-GCC-exception"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-with-GCC-exception;md5=aef5f35c9272f508be848cd99e0151df"
 
-SRC_URI = "git://gcc.gnu.org/gcc.git;tag=releases/gcc-11.3.0;subpath=libatomic;protocol=https"
+SRC_URI = "git://gcc.gnu.org/gcc.git;branch=releases/gcc-10.5.0;subpath=libatomic;protocol=https"
+PV = "1.0+git${SRCPV}"
+SRCREV = "d04fe5541c53cb16d1ca5c80da044b4c7633dbc6"
 
 inherit autotools


### PR DESCRIPTION
New in release OpenJDK 8u392 (2023-10-17):
===========================================
Live versions of these release notes can be found at:
https://bit.ly/openjdk8u392

* CVEs
  - CVE-2023-22067
  - CVE-2023-22081
* Security fixes
  - JDK-8286503, JDK-8312367: Enhance security classes
  - JDK-8297856: Improve handling of Bidi characters
  - JDK-8303384: Improved communication in CORBA
  - JDK-8305815, JDK-8307278: Update Libpng to 1.6.39
  - JDK-8309966: Enhanced TLS connections
* Other changes
  - JDK-6722928: Provide a default native GSS-API library on Windows
  - JDK-8040887: [TESTBUG] Remove test/runtime/6925573/SortMethodsTest.java
  - JDK-8042726: [TESTBUG] TEST.groups file was not updated after runtime/6925573/SortMethodsTest.java removal
  - JDK-8139348: Deprecate 3DES and RC4 in Kerberos
  - JDK-8173072: zipfs fails to handle incorrect info-zip "extended timestamp extra field"
  - JDK-8200468: Port the native GSS-API bridge to Windows
  - JDK-8202952: C2: Unexpected dead nodes after matching
  - JDK-8205399: Set node color on pinned HashMap.TreeNode deletion
  - JDK-8209115: adjust libsplashscreen linux ppc64le builds for easier libpng update
  - JDK-8214046: [macosx] Undecorated Frame does not Iconify when set to
  - JDK-8219804: java/net/MulticastSocket/Promiscuous.java fails intermittently due to NumberFormatException
  - JDK-8225687: Newly added sspi.cpp in JDK-6722928 still contains some small errors
  - JDK-8232225: Rework the fix for JDK-8071483
  - JDK-8242330: Arrays should be cloned in several JAAS Callback classes
  - JDK-8253269: The CheckCommonColors test should provide more info on failure
  - JDK-8283441: C2: segmentation fault in ciMethodBlocks::make_block_at(int)
  - JDK-8284910: Buffer clean in PasswordCallback
  - JDK-8287073: NPE from CgroupV2Subsystem.getInstance()
  - JDK-8287663: Add a regression test for JDK-8287073
  - JDK-8295685: Update Libpng to 1.6.38
  - JDK-8295894: Remove SECOM certificate that is expiring in September 2023
  - JDK-8308788: [8u] Remove duplicate HaricaCA.java test
  - JDK-8309122: Bump update version of OpenJDK: 8u392
  - JDK-8309143: [8u] fix archiving inconsistencies in GHA
  - JDK-8310026: [8u] make java_lang_String::hash_code consistent across platforms
  - JDK-8314960: Add Certigna Root CA - 2
  - JDK-8315135: Memory leak in the native implementation of Pack200.Unpacker.unpack()
  - JDK-8317040: Exclude cleaner test failing on older releases