### PR TITLE
kirkstone: recipes-graphics: Provide recipe of libfreetype6 in version 2.13.1

### DIFF
--- a/recipes-graphics/freetype/freetype_2.13.1.bb
+++ b/recipes-graphics/freetype/freetype_2.13.1.bb
@@ -1,0 +1,45 @@
+SUMMARY = "Freetype font rendering library"
+DESCRIPTION = "FreeType is a software font engine that is designed to be small, efficient, \
+highly customizable, and portable while capable of producing high-quality output (glyph \
+images). It can be used in graphics libraries, display servers, font conversion tools, text \
+image generation tools, and many other products as well."
+HOMEPAGE = "http://www.freetype.org/"
+BUGTRACKER = "https://savannah.nongnu.org/bugs/?group=freetype"
+SECTION = "libs"
+
+LICENSE = "(FTL | GPL-2.0-or-later) & MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
+                    file://${COMMON_LICENSE_DIR}/FTL;md5=f0bf6b09ee8b02121ed10709d9e49d8b \
+                    file://${COMMON_LICENSE_DIR}/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c \
+                    "
+
+SRC_URI = "${SAVANNAH_NONGNU_MIRROR}/${BPN}/${BP}.tar.xz"
+SRC_URI[sha256sum] = "ea67e3b019b1104d1667aa274f5dc307d8cbd606b399bc32df308a77f1a564bf"
+
+UPSTREAM_CHECK_REGEX = "freetype-(?P<pver>\d+(\.\d+)+)"
+
+inherit autotools pkgconfig multilib_header
+
+# Adapt autotools to work with the minimal autoconf usage in freetype
+AUTOTOOLS_SCRIPT_PATH = "${S}/builds/unix"
+CONFIGURE_SCRIPT = "${S}/configure"
+EXTRA_AUTORECONF += "--exclude=autoheader --exclude=automake"
+
+PACKAGECONFIG ??= "zlib pixmap"
+
+PACKAGECONFIG[bzip2] = "--with-bzip2,--without-bzip2,bzip2"
+# harfbuzz results in a circular dependency so enabling is non-trivial
+PACKAGECONFIG[harfbuzz] = "--with-harfbuzz,--without-harfbuzz,harfbuzz"
+PACKAGECONFIG[pixmap] = "--with-png,--without-png,libpng"
+PACKAGECONFIG[zlib] = "--with-zlib,--without-zlib,zlib"
+PACKAGECONFIG[freetypeconfig] = "--enable-freetype-config=yes,--enable-freetype-config=no,"
+
+EXTRA_OECONF = "CC_BUILD='${BUILD_CC}'"
+
+TARGET_CPPFLAGS += "-D_FILE_OFFSET_BITS=64"
+
+do_install:append() {
+	oe_multilib_header freetype2/freetype/config/ftconfig.h
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This is a backport of the recipe of libfreetype6 from the Yocto Project.
It satisfies the dependency of openjdk-11-jre-11.0.21+9 for libfreetype6.
Origin of recipe: https://git.yoctoproject.org/poky/tree/meta/recipes-graphics/freetype?h=mickledore