### PR TITLE
Set correct runtime linker for java binaries (main)

### DIFF
--- a/recipes-core/openjdk-11-jre/openjdk-11-jre_11.0.21+9.bb
+++ b/recipes-core/openjdk-11-jre/openjdk-11-jre_11.0.21+9.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-with-classpath-exceptio
 COMPATIBLE_HOST = "(x86_64|arm|aarch64).*-linux"
 OVERRIDES = "${TARGET_ARCH}"
 
+DEPENDS = "patchelf-native"
+
 JVM_CHECKSUM:aarch64 = "8dc527e5c5da62f80ad3b6a2cd7b1789f745b1d90d5e83faba45f7a1d0b6cab8"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
@@ -80,6 +82,13 @@ do_compile[noexec] = "1"
 do_install() {
   install -d ${D}${libdir_jre}
   cp -R --no-dereference --preserve=mode,links -v ${S}/* ${D}${libdir_jre}
+
+  LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux-* | sort | head -n1))
+  if [ -n "$LDLINUX" ]; then
+    for i in ${D}${libdir}/jvm/${BPN}/bin/* ; do
+      patchelf --set-interpreter ${base_libdir}/$LDLINUX $i
+    done
+  fi
 }
 
 RPROVIDES:${PN} = "java2-runtime"

--- a/recipes-core/openjdk-17-jre/openjdk-17-jre_17.0.9+9.bb
+++ b/recipes-core/openjdk-17-jre/openjdk-17-jre_17.0.9+9.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-with-classpath-exceptio
 COMPATIBLE_HOST = "(x86_64|arm|aarch64).*-linux"
 OVERRIDES = "${TARGET_ARCH}"
 
+DEPENDS = "patchelf-native"
+
 JVM_CHECKSUM:aarch64 = "05b192f81ed478178ba953a2a779b67fc5a810acadb633ad69f8c4412399edb8"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
@@ -80,6 +82,13 @@ do_compile[noexec] = "1"
 do_install() {
   install -d ${D}${libdir_jre}
   cp -R --no-dereference --preserve=mode,links -v ${S}/* ${D}${libdir_jre}
+
+  LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux-* | sort | head -n1))
+  if [ -n "$LDLINUX" ]; then
+    for i in ${D}${libdir}/jvm/${BPN}/bin/* ; do
+      patchelf --set-interpreter ${base_libdir}/$LDLINUX $i
+    done
+  fi
 }
 
 RPROVIDES:${PN} = "java2-runtime"

--- a/recipes-core/openjdk-21-jre/openjdk-21-jre_21.0.1+12.bb
+++ b/recipes-core/openjdk-21-jre/openjdk-21-jre_21.0.1+12.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-with-classpath-exceptio
 COMPATIBLE_HOST = "(x86_64|aarch64).*-linux"
 OVERRIDES = "${TARGET_ARCH}"
 
+DEPENDS = "patchelf-native"
+
 JVM_CHECKSUM:aarch64 = "4582c4cc0c6d498ba7a23fdb0a5179c9d9c0d7a26f2ee8610468d5c2954fcf2f"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
@@ -66,6 +68,13 @@ do_compile[noexec] = "1"
 do_install() {
   install -d ${D}${libdir_jre}
   cp -R --no-dereference --preserve=mode,links -v ${S}/* ${D}${libdir_jre}
+
+  LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux-* | sort | head -n1))
+  if [ -n "$LDLINUX" ]; then
+    for i in ${D}${libdir}/jvm/${BPN}/bin/* ; do
+      patchelf --set-interpreter ${base_libdir}/$LDLINUX $i
+    done
+  fi
 }
 
 RPROVIDES:${PN} = "java2-runtime"

--- a/recipes-core/openjdk-8-jre/openjdk-8-jre_8u392-b08.bb
+++ b/recipes-core/openjdk-8-jre/openjdk-8-jre_8u392-b08.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-with-classpath-exceptio
 COMPATIBLE_HOST = "(x86_64|arm|aarch64).*-linux"
 OVERRIDES = "${TARGET_ARCH}"
 
+DEPENDS = "patchelf-native"
+
 JVM_CHECKSUM:aarch64 = "37b997f12cd572da979283fccafec9ba903041a209605b50fcb46cc34f1a9917"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
@@ -80,6 +82,13 @@ do_compile[noexec] = "1"
 do_install() {
   install -d ${D}${libdir_jre}
   cp -R --no-dereference --preserve=mode,links -v ${S}/* ${D}${libdir_jre}
+
+  LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux-* | sort | head -n1))
+  if [ -n "$LDLINUX" ]; then
+    for i in ${D}${libdir}/jvm/${BPN}/bin/* ; do
+      patchelf --set-interpreter ${base_libdir}/$LDLINUX $i
+    done
+  fi
 }
 
 RPROVIDES:${PN} = "java2-runtime"


### PR DESCRIPTION
This fixes #23 in all combinations of `multilib` and `usrmerge` settings in `DISTRO_FEATURES`.