### PR TITLE
main: openjdk-21-jre: Upgrade 21.0.1+12 -> 21.0.2+13

### DIFF
--- a/recipes-core/openjdk-21-jre/openjdk-21-jre_21.0.2+13.bb
+++ b/recipes-core/openjdk-21-jre/openjdk-21-jre_21.0.2+13.bb
@@ -8,7 +8,7 @@ OVERRIDES = "${TARGET_ARCH}"
 
 DEPENDS = "patchelf-native"
 
-JVM_CHECKSUM:aarch64 = "4582c4cc0c6d498ba7a23fdb0a5179c9d9c0d7a26f2ee8610468d5c2954fcf2f"
+JVM_CHECKSUM:aarch64 = "64c78854184c92a4da5cda571c8e357043bfaf03a03434eef58550cc3410d8a4"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.13) \
@@ -20,7 +20,7 @@ JVM_RDEPENDS:aarch64 = " \
   libxtst (>= 1.2) \
   zlib (>= 1.1.4) \
 "
-JVM_CHECKSUM:x86_64 = "277f4084bee875f127a978253cfbaad09c08df597feaf5ccc82d2206962279a3"
+JVM_CHECKSUM:x86_64 = "51141204fe01a9f9dd74eab621d5eca7511eac67315c9975dbde5f2625bdca55"
 JVM_RDEPENDS:x86_64 = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.13) \


### PR DESCRIPTION
Changes worth mentioning:
- JDK-8319720: Build on windows fails after 8316645
- JDK-8323082: [BACKOUT] 8318562: Computational test more than 2x slower when AVX instructions are used
- JDK-8319740: Add Let's Encrypt ISRG Root X2
- JDK-8320287: Add four DigiCert root certificates
- JDK-8320432: Add three eMudhra emSign roots
- JDK-8318748: Add Telia Root CA v2

Full release notes: https://adoptium.net/temurin/release-notes/?version=jdk-21.0.2+13