### PR TITLE
kirkstone: openjdk-8-jre: Upgrade 8u392-b08 -> 8u402-b06

### DIFF
--- a/recipes-core/openjdk-8-jre/openjdk-8-jre_8u402-b06.bb
+++ b/recipes-core/openjdk-8-jre/openjdk-8-jre_8u402-b06.bb
@@ -8,7 +8,7 @@ OVERRIDES = "${TARGET_ARCH}"
 
 DEPENDS = "patchelf-native"
 
-JVM_CHECKSUM:aarch64 = "37b997f12cd572da979283fccafec9ba903041a209605b50fcb46cc34f1a9917"
+JVM_CHECKSUM:aarch64 = "782f842c22fe660c5acbea8c1d7b4e812fe658a9e48cd2e8e776d088c7ab32d3"
 JVM_RDEPENDS:aarch64 = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.11) \
@@ -20,7 +20,7 @@ JVM_RDEPENDS:aarch64 = " \
   libxrender (>= 0.9) \
   libxtst (>= 1.2) \
 "
-JVM_CHECKSUM:arm = "877953bfabcdbcd000c11364d806456ca579a921085de2ca942280ebe168cac2"
+JVM_CHECKSUM:arm = "d613a775573fc17ee972e62b5120dc34d8cac1810bb352e71bc01980ce3c48a8"
 JVM_RDEPENDS:arm = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.11) \
@@ -33,7 +33,7 @@ JVM_RDEPENDS:arm = " \
   libxrender (>= 0.9) \
   libxtst (>= 1.2) \
 "
-JVM_CHECKSUM:x86_64 = "91d31027da0d985be3549714389593d9e0da3da5057d87e3831c7c538b9a2a0f"
+JVM_CHECKSUM:x86_64 = "1d8c109e96bdb35ffff667dfb911ce03fb9f0f924048dcc8fdbd45198b263ecd"
 JVM_RDEPENDS:x86_64 = " \
   alsa-lib (>= 0.9) \
   freetype (>= 2.11) \


### PR DESCRIPTION
Changes worth mentioning:
- JDK-8322257: Add Telia Root CA v2
- JDK-8322258: Add Let's Encrypt ISRG Root X2
- JDK-8322259: Add four DigiCert root certificates
- JDK-8322260: Add three eMudhra emSign roots

Full release notes: https://adoptium.net/de/temurin/release-notes/?version=jdk8u402-b06
Mirror: https://github.com/lucimber/meta-openjdk-temurin/issues/29