### PR TITLE
GitHub Actions: Print log file of BitBake if it fails with non-zero status code

### DIFF
--- a/.github/workflows/bitbake-main-local.conf
+++ b/.github/workflows/bitbake-main-local.conf
@@ -13,7 +13,4 @@ BB_DISKMON_DIRS ??= "\
     HALT,${SSTATE_DIR},100M,1K \
     HALT,/tmp,10M,1K"
 
-BB_SIGNATURE_HANDLER = "OEEquivHash"
-BB_HASHSERVE = "auto"
-BB_HASHSERVE_UPSTREAM = "hashserv.yocto.io:8687"
 SSTATE_MIRRORS ?= "file://.* https://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Add layer to build-environment
         run: |
           cd oe-core
-          source oe-init-build-env build > /dev/null 2>&1
-          bitbake-layers add-layer ../meta-openjdk-temurin
+          source oe-init-build-env build
+          bitbake-layers add-layer ../meta-openjdk-temurin \
+          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -68,8 +69,9 @@ jobs:
       - name: Build ${{ matrix.recipe }} with Bitbake
         run: |
           cd oe-core
-          source oe-init-build-env build > /dev/null 2>&1
-          MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }}
+          source oe-init-build-env build
+          MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }} \
+          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           cd oe-core
           source oe-init-build-env build > /dev/null 2>&1
-          bitbake-layers add-layer ../meta-openjdk-temurin
+          bitbake-layers -d add-layer ../meta-openjdk-temurin
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd oe-core
           source oe-init-build-env build > /dev/null 2>&1
-          MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }}
+          MACHINE=${{ matrix.machine }} bitbake -D ${{ matrix.recipe }}
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -60,7 +60,8 @@ jobs:
           export LANG="en_US.UTF-8"
           export LANGUAGE="en_US.UTF-8"
           cd oe-core
-          source oe-init-build-env build > /dev/null
+          source oe-init-build-env build
+          ls -lh
           rm -rfv bitbake.lock
           bitbake-layers -d add-layer ../meta-openjdk-temurin
       - name: Restore cached sstate of Bitbake

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -56,6 +56,9 @@ jobs:
             conf/local.conf
       - name: Add layer to build-environment
         run: |
+          export LC_ALL="en_US.UTF-8"
+          export LANG="en_US.UTF-8"
+          export LANGUAGE="en_US.UTF-8"
           cd oe-core
           source oe-init-build-env build > /dev/null
           bitbake-layers -d add-layer ../meta-openjdk-temurin
@@ -67,6 +70,9 @@ jobs:
           key: bitbake-sstate_main_${{ matrix.machine }}
       - name: Build ${{ matrix.recipe }} with Bitbake
         run: |
+          export LC_ALL="en_US.UTF-8"
+          export LANG="en_US.UTF-8"
+          export LANGUAGE="en_US.UTF-8"
           cd oe-core
           source oe-init-build-env build > /dev/null
           MACHINE=${{ matrix.machine }} bitbake -D ${{ matrix.recipe }}

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -59,7 +59,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           bitbake-layers add-layer ../meta-openjdk-temurin \
-            || cat bitbake-cookerdaemon.log
+          || cat bitbake-cookerdaemon.log
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -71,7 +71,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }} \
-            || cat bitbake-cookerdaemon.log
+          || cat bitbake-cookerdaemon.log
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -20,7 +20,7 @@ jobs:
           - recipe: openjdk-21-jre
             machine: qemuarm
       max-parallel: 3
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install software required by OpenEmbedded / Yocto
         run: |

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -51,13 +51,13 @@ jobs:
       - name: Replace config of build-environment
         run: |
           cd oe-core
-          source oe-init-build-env build > /dev/null 2>&1
+          source oe-init-build-env build > /dev/null
           mv -v ../meta-openjdk-temurin/.github/workflows/bitbake-main-local.conf \
             conf/local.conf
       - name: Add layer to build-environment
         run: |
           cd oe-core
-          source oe-init-build-env build > /dev/null 2>&1
+          source oe-init-build-env build > /dev/null
           bitbake-layers -d add-layer ../meta-openjdk-temurin
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
@@ -68,7 +68,7 @@ jobs:
       - name: Build ${{ matrix.recipe }} with Bitbake
         run: |
           cd oe-core
-          source oe-init-build-env build > /dev/null 2>&1
+          source oe-init-build-env build > /dev/null
           MACHINE=${{ matrix.machine }} bitbake -D ${{ matrix.recipe }}
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -59,7 +59,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           bitbake-layers add-layer ../meta-openjdk-temurin \
-          || cat bitbake-cookerdaemon.log
+          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -71,7 +71,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }} \
-          || cat bitbake-cookerdaemon.log
+          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -59,7 +59,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           bitbake-layers add-layer ../meta-openjdk-temurin \
-          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
+          || cat bitbake-cookerdaemon.log
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -71,7 +71,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }} \
-          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
+          || cat bitbake-cookerdaemon.log
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -61,6 +61,7 @@ jobs:
           export LANGUAGE="en_US.UTF-8"
           cd oe-core
           source oe-init-build-env build > /dev/null
+          rm -rfv bitbake.lock
           bitbake-layers -d add-layer ../meta-openjdk-temurin
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
@@ -75,6 +76,7 @@ jobs:
           export LANGUAGE="en_US.UTF-8"
           cd oe-core
           source oe-init-build-env build > /dev/null
+          rm -rfv bitbake.lock
           MACHINE=${{ matrix.machine }} bitbake -D ${{ matrix.recipe }}
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -59,7 +59,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           bitbake-layers add-layer ../meta-openjdk-temurin \
-          || cat bitbake-cookerdaemon.log
+            || cat bitbake-cookerdaemon.log
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -71,7 +71,7 @@ jobs:
           cd oe-core
           source oe-init-build-env build
           MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }} \
-          || cat bitbake-cookerdaemon.log
+            || cat bitbake-cookerdaemon.log
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/bitbake-main.yml
+++ b/.github/workflows/bitbake-main.yml
@@ -57,9 +57,8 @@ jobs:
       - name: Add layer to build-environment
         run: |
           cd oe-core
-          source oe-init-build-env build
-          bitbake-layers add-layer ../meta-openjdk-temurin \
-          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
+          source oe-init-build-env build > /dev/null 2>&1
+          bitbake-layers add-layer ../meta-openjdk-temurin
       - name: Restore cached sstate of Bitbake
         id: cache-bitbake-sstate-restore
         uses: actions/cache/restore@v3
@@ -69,9 +68,8 @@ jobs:
       - name: Build ${{ matrix.recipe }} with Bitbake
         run: |
           cd oe-core
-          source oe-init-build-env build
-          MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }} \
-          if [ $? -ne 0 ]; then cat bitbake-cookerdaemon.log; fi
+          source oe-init-build-env build > /dev/null 2>&1
+          MACHINE=${{ matrix.machine }} bitbake ${{ matrix.recipe }}
       - name: Save sstate of Bitbake
         id: cache-bitbake-sstate-save
         if: steps.cache-bitbake-sstate-restore.outputs.cache-hit != 'true'


### PR DESCRIPTION
BitBake fails silently recently...

The only hint are the error messages printed as:
* NOTE: Starting bitbake server...
* NOTE: No reply from server in 30s (for command updateConfig at 10:54:17.809867)
* NOTE: No reply from server in 30s (for command clientComplete at 10:55:17.870367)
* Timeout while waiting for a reply from the bitbake server (60s at 10:55:47.900586)

This PR tries to solve that issue by providing more information in case of error.