### PR TITLE
openjdk-17, openjdk-21: fix ADAPTED_PV_SRC setting

### DIFF
--- a/recipes-core/openjdk-17/openjdk-17-base.inc
+++ b/recipes-core/openjdk-17/openjdk-17-base.inc
@@ -14,7 +14,7 @@ API_JVM_IMPL = "hotspot"
 API_HEAP_SIZE ?= "normal"
 API_VENDOR = "eclipse"
 
-ADAPTED_PV_SRC = "${@d.getVar('PV').replace('-','')}"
+ADAPTED_PV_SRC = "${@d.getVar('PV').replace('-','').replace('+','_')}"
 SRC_URI = "https://api.adoptium.net/v3/binary/version/${API_RELEASE_NAME}/${API_OS}/${API_ARCH}/${API_IMAGE_TYPE}/${API_JVM_IMPL}/${API_HEAP_SIZE}/${API_VENDOR};name=binary;downloadfilename=${BPN}-${API_ARCH}-${PV}.tar.gz;subdir=${BPN}-${PV};striplevel=1 \
            https://github.com/adoptium/temurin17-binaries/releases/download/${API_RELEASE_NAME}/OpenJDK17U-jdk-sources_${ADAPTED_PV_SRC}.tar.gz;name=sources;downloadfilename=${BPN}-sources-${PV}.tar.gz;unpack=false"
 SRC_URI[binary.sha256sum] = "${JVM_CHECKSUM}"

--- a/recipes-core/openjdk-21/openjdk-21-base.inc
+++ b/recipes-core/openjdk-21/openjdk-21-base.inc
@@ -13,7 +13,7 @@ API_JVM_IMPL = "hotspot"
 API_HEAP_SIZE ?= "normal"
 API_VENDOR = "eclipse"
 
-ADAPTED_PV_SRC = "${@d.getVar('PV').replace('-','')}"
+ADAPTED_PV_SRC = "${@d.getVar('PV').replace('-','').replace('+','_')}"
 SRC_URI = "https://api.adoptium.net/v3/binary/version/${API_RELEASE_NAME}/${API_OS}/${API_ARCH}/${API_IMAGE_TYPE}/${API_JVM_IMPL}/${API_HEAP_SIZE}/${API_VENDOR};name=binary;downloadfilename=${BPN}-${API_ARCH}-${PV}.tar.gz;subdir=${BPN}-${PV};striplevel=1 \
            https://github.com/adoptium/temurin21-binaries/releases/download/${API_RELEASE_NAME}/OpenJDK21U-jdk-sources_${ADAPTED_PV_SRC}.tar.gz;name=sources;downloadfilename=${BPN}-sources-${PV}.tar.gz;unpack=false"
 SRC_URI[binary.sha256sum] = "${JVM_CHECKSUM}"


### PR DESCRIPTION
to rewrite the '+' to '_' in the version number.

This was already done for openjdk-11 in #62 , but I missed updating 17 and 21, and didn't catch it due to the sources tarball already being in my build workspace.