### PR TITLE
recipes-core: fix ldlinux path in all executables

### DIFF
--- a/recipes-core/openjdk-11/openjdk-11-target.inc
+++ b/recipes-core/openjdk-11/openjdk-11-target.inc
@@ -29,13 +29,7 @@ do_install() {
 
   LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux* | sort | head -n1))
   if [ -n "$LDLINUX" ]; then
-    for i in ${D}${libdir_jvm}/bin/*; do
-      if file "$i" | grep -q ELF; then
-        patchelf --set-interpreter ${base_libdir}/$LDLINUX "$i"
-      else
-        bbnote "Skipping non-ELF file: $i"
-      fi
-    done
+    find ${D}${libdir_jvm} -type f -executable -exec patchelf --set-interpreter ${base_libdir}/$LDLINUX {} \;
   fi
 }
 

--- a/recipes-core/openjdk-17/openjdk-17-target.inc
+++ b/recipes-core/openjdk-17/openjdk-17-target.inc
@@ -29,13 +29,7 @@ do_install() {
 
   LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux* | sort | head -n1))
   if [ -n "$LDLINUX" ]; then
-    for i in ${D}${libdir_jvm}/bin/*; do
-      if file "$i" | grep -q ELF; then
-        patchelf --set-interpreter ${base_libdir}/$LDLINUX "$i"
-      else
-        bbnote "Skipping non-ELF file: $i"
-      fi
-    done
+    find ${D}${libdir_jvm} -type f -executable -exec patchelf --set-interpreter ${base_libdir}/$LDLINUX {} \;
   fi
 }
 

--- a/recipes-core/openjdk-21/openjdk-21-target.inc
+++ b/recipes-core/openjdk-21/openjdk-21-target.inc
@@ -29,13 +29,7 @@ do_install() {
 
   LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux* | sort | head -n1))
   if [ -n "$LDLINUX" ]; then
-    for i in ${D}${libdir_jvm}/bin/*; do
-      if file "$i" | grep -q ELF; then
-        patchelf --set-interpreter ${base_libdir}/$LDLINUX "$i"
-      else
-        bbnote "Skipping non-ELF file: $i"
-      fi
-    done
+    find ${D}${libdir_jvm} -type f -executable -exec patchelf --set-interpreter ${base_libdir}/$LDLINUX {} \;
   fi
 }
 

--- a/recipes-core/openjdk-8/openjdk-8-target.inc
+++ b/recipes-core/openjdk-8/openjdk-8-target.inc
@@ -29,13 +29,7 @@ do_install() {
 
   LDLINUX=$(basename $(ls -1 ${RECIPE_SYSROOT}${base_libdir}/ld-linux* | sort | head -n1))
   if [ -n "$LDLINUX" ]; then
-    for i in ${D}${libdir_jvm}/bin/*; do
-      if file "$i" | grep -q ELF; then
-        patchelf --set-interpreter ${base_libdir}/$LDLINUX "$i"
-      else
-        bbnote "Skipping non-ELF file: $i"
-      fi
-    done
+    find ${D}${libdir_jvm} -type f -executable -exec patchelf --set-interpreter ${base_libdir}/$LDLINUX {} \;
   fi
 }
 


### PR DESCRIPTION
Currently we patch executables in the bin directory, but there are some executables in lib which also need patching.

I ran into this issue because my application calls `Runtime.exec()`, which in turn invokes `lib/jspawnhelper`. 