### PR TITLE
conf/layer.conf: Add wrynose to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-openjdk-temurin = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-openjdk-temurin = "6"
 
 LAYERDEPENDS_meta-openjdk-temurin = "core"
-LAYERSERIES_COMPAT_meta-openjdk-temurin = "whinlatter walnascar styhead scarthgap nanbield"
+LAYERSERIES_COMPAT_meta-openjdk-temurin = "wrynose whinlatter walnascar styhead scarthgap nanbield"


### PR DESCRIPTION
Tested the build of all jdk and jre recipes for x86_64, no issues.